### PR TITLE
actions fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,6 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        # For example, using `pytest`
         run: uv run pytest tests --junit-xml=test-results.xml
 
       - name: Upload test results
@@ -53,19 +52,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      # with:
+      #   fetch-depth: 0
 
     - run: git fetch --tags
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3
-
-    # - name: Set up Python
-    #   run: uv python install
-
-    # - name: Install the project
-    #   run: uv sync --all-extras --dev --no-install-project
 
     - name: Build dist
       run: uv build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,6 +53,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - run: git fetch --tags
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,8 +52,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      # with:
-      #   fetch-depth: 0
 
     - run: git fetch --tags
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,24 +67,24 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  # publish-to-pypi:
-  #   name: >-
-  #     Publish Python 🐍 distribution 📦 to PyPI
-  #   if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-  #   needs:
-  #     - build
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/rv-script-utils
-  #   permissions:
-  #     id-token: write
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rv-script-utils
+    permissions:
+      id-token: write
 
-  #   steps:
-  #     - name: Download all the dists
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: python-package-distributions
-  #         path: dist/
-  #     - name: Publish distribution 📦 to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,11 +61,11 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v3
 
-    - name: Set up Python
-      run: uv python install
+    # - name: Set up Python
+    #   run: uv python install
 
-    - name: Install the project
-      run: uv sync --all-extras --dev --no-install-project
+    # - name: Install the project
+    #   run: uv sync --all-extras --dev --no-install-project
 
     - name: Build dist
       run: uv build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,8 +53,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-tags: true
+
+    - run: git fetch --tags
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       run: uv python install
 
     - name: Install the project
-      run: uv sync --all-extras --dev
+      run: uv sync --all-extras --dev --no-install-project
 
     - name: Build dist
       run: uv build
@@ -76,24 +76,24 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/rv-script-utils
-    permissions:
-      id-token: write
+  # publish-to-pypi:
+  #   name: >-
+  #     Publish Python 🐍 distribution 📦 to PyPI
+  #   if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+  #   needs:
+  #     - build
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/rv-script-utils
+  #   permissions:
+  #     id-token: write
 
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #   steps:
+  #     - name: Download all the dists
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: python-package-distributions
+  #         path: dist/
+  #     - name: Publish distribution 📦 to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ testpaths = [
 ]
 
 [tool.setuptools_scm]
-write_to = "src/rv_script_lib/_version.py"
+version_file = "src/rv_script_lib/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@ testpaths = [
 
 [tool.setuptools_scm]
 version_file = "src/rv_script_lib/_version.py"
+local_scheme = "no-local-version"


### PR DESCRIPTION
This corrects the github actions config.

`uv` continues to impress me, but I found that in doing the `sync`, it seemed to break the build version obtained from `setuptools-scm`.  By removing everything except `setup-uv` and `uv build`, that allowed `setuptools-scm` to obtain the version correctly from github actions.